### PR TITLE
localizedPathFor was not working properly when passed an URL that alr…

### DIFF
--- a/app/assets/javascripts/spree.js
+++ b/app/assets/javascripts/spree.js
@@ -32,7 +32,7 @@ Spree.localizedPathFor = function(path) {
     if (pathName.match(/api\/v/)) {
       params.set('locale', SPREE_LOCALE)
     } else {
-      pathName = (this.mountedAt()) + SPREE_LOCALE + '/' + path
+      pathName = (this.mountedAt()) + SPREE_LOCALE + '/' + pathName
     }
     return fullUrl.origin + pathName + '?' + params.toString()
   }


### PR DESCRIPTION
…eady contained params (produced result like url?param=1?param=1)