### PR TITLE
 if request.env['HTTP_REFERER'] is nil, should_build_new_url? errors …

### DIFF
--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -27,10 +27,11 @@ module Spree
     private
 
     def should_build_new_url?
+      return false if request.env['HTTP_REFERER'].blank?
       if request.env['HTTP_REFERER'].match(REDIRECT_TO_ROOT)
         false
       else
-        request.env['HTTP_REFERER'].present? && request.env['HTTP_REFERER'] != request.env['REQUEST_URI']
+        request.env['HTTP_REFERER'] != request.env['REQUEST_URI']
       end
     end
   end


### PR DESCRIPTION
…out in first if condition, even though the else would then check for presence