### PR TITLE
Fix CMS attachment checks

### DIFF
--- a/app/views/spree/shared/cms/sections/_hero_image.html.erb
+++ b/app/views/spree/shared/cms/sections/_hero_image.html.erb
@@ -10,7 +10,7 @@
 <div class="col-12 homepage-hero-image position-relative p-0 <%= section_padding %>">
 
   <div class="bg-light" style="--aspect-ratio:12/5;">
-    <% if section.image_one.attached? %>
+    <% if section.image_one&.attachment&.attached? %>
 
         <!-- SM to MD -->
         <img class="d-block d-md-none lazyload"

--- a/app/views/spree/shared/cms/sections/_image_gallery.html.erb
+++ b/app/views/spree/shared/cms/sections/_image_gallery.html.erb
@@ -64,7 +64,7 @@
     <div class="col-12">
 
       <%= link_to link_one, class: link_one_classes, style: '--aspect-ratio:18/13;' do %>
-        <% if section.image_one.attached? && section.image_one.variable? %>
+        <% if section.image_one&.attachment&.attached? && section.image_one&.attachment&.variable? %>
 
             <!-- XS to MD -->
             <img class="d-md-none lazyload"
@@ -102,7 +102,7 @@
     <div class="col-12">
 
       <%= link_to link_three, class: link_three_classes, style: '--aspect-ratio:18/13;' do %>
-        <% if section.image_three.attached? && section.image_three.variable? %>
+        <% if section.image_three&.attachment&.attached? && section.image_three&.attachment&.variable? %>
 
             <!-- XS to MD -->
             <img class="d-md-none lazyload"
@@ -139,7 +139,7 @@
 <!-- Right Block TALL -->
 <div class="col-6 <%= section_two_padding %>">
   <%= link_to link_two, class: link_two_classes, style: '--aspect-ratio:27/40;' do %>
-    <% if section.image_two.attached? && section.image_two.variable? %>
+    <% if section.image_two&.attachment&.attached? && section.image_two&.attachment&.variable? %>
 
         <!-- XS to MD -->
         <img class="d-md-none lazyload"

--- a/app/views/spree/shared/cms/sections/_side_by_side_images.html.erb
+++ b/app/views/spree/shared/cms/sections/_side_by_side_images.html.erb
@@ -36,7 +36,7 @@
               class: "d-flex align-items-end justify-content-center bg-light text-center overflow-hidden homepage-bottom-box #{'pointer-events-none cursor-default' unless link_one}",
               style: '--aspect-ratio:54/35;' do %>
 
-      <% if section.image_one.attached? %>
+      <% if section.image_one&.attachment&.attached? %>
         <!-- XS to MD -->
         <img class="d-md-none lazyload"
           data-src="<%= main_app.cdn_image_url(section.img_one_md) %>"
@@ -79,7 +79,7 @@
               class: "d-flex align-items-end justify-content-center bg-light text-center overflow-hidden homepage-bottom-box #{'pointer-events-none cursor-default' unless link_two}",
               style: '--aspect-ratio:54/35;' do %>
 
-      <% if section.image_two.attached? %>
+      <% if section.image_two&.attachment&.attached? %>
         <!-- XS to MD -->
           <img class="d-md-none lazyload"
             data-src="<%= main_app.cdn_image_url(section.img_two_md) %>"


### PR DESCRIPTION
4.5 changed the internal structure used for storing images, so we need to go through another association when checking if image is attached to a section.