### PR TITLE
Add troubleshooting for disabled 'Add to Cart' button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn build
 #### Disabled 'Add to Cart' Button Issue
 
 If you notice that the 'Add to Cart' button is disabled on product pages, try the following:
-* run `yarn build` again
+* run `yarn build` again in your main repo
 * if that doesn't fix the issue, try running the following setup commands again:
   ```
   bin/rails javascript:install:esbuild
@@ -41,7 +41,7 @@ If you notice that the 'Add to Cart' button is disabled on product pages, try th
   bin/rails g spree:frontend:install
   ```
 
-This issue may come up if you switch the source of your `spree_frontend` in your spree_starter Gemfile, e.g. from github to a local path, etc.
+This issue may come up if you switch the source of your `spree_frontend` in your Gemfile, e.g. from github to a local path, etc.
 
 ## Maintanence policy
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,23 @@ bundle install
 bin/rails javascript:install:esbuild
 bin/rails turbo:install
 bin/rails g spree:frontend:install
+yarn build
 ```
+
+### Troubleshooting
+
+#### Disabled 'Add to Cart' Button Issue
+
+If you notice that the 'Add to Cart' button is disabled on product pages, try the following:
+* run `yarn build` again
+* if that doesn't fix the issue, try running the following setup commands again:
+  ```
+  bin/rails javascript:install:esbuild
+  bin/rails turbo:install
+  bin/rails g spree:frontend:install
+  ```
+
+This issue may come up if you switch the source of your `spree_frontend` in your spree_starter Gemfile, e.g. from github to a local path, etc.
 
 ## Maintanence policy
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you notice that the 'Add to Cart' button is disabled on product pages, try th
   bin/rails javascript:install:esbuild
   bin/rails turbo:install
   bin/rails g spree:frontend:install
+  yarn build
   ```
 
 This issue may come up if you switch the source of your `spree_frontend` in your Gemfile, e.g. from github to a local path, etc.


### PR DESCRIPTION
'Add to Cart' button is disabled on product pages if `yarn build` command is not run - add `yarn build` to setup commands. The problem also comes up when switching the source of the `spree_frontend` gem, add note on this to troubleshooting and include commands for how to fix.