### PR TITLE
Fix add to cart button

### DIFF
--- a/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
+++ b/app/assets/javascripts/spree/frontend/views/spree/products/cart_form.js
@@ -190,7 +190,7 @@ function CartForm($, $cartForm) {
 
     return this.variants.find(function(variant) {
       var optionValueIds = variant.option_values.map(function(ov) {
-        return ov.id
+        return ov.id.toString()
       })
 
       return self.areArraysEqual(optionValueIds, self.selectedOptionValueIds)


### PR DESCRIPTION
Currently the add to cart button remains disabled after picking all the required option types. This is a bug in comparing selected option value ids (strings, since they come from data attributes in html dom) to option value ids for available variants (numbers). 

We do a `.toString()` on option value ids in other places already, so I made it consistent