### PR TITLE
change locale controller to save local for user if locale on page changes

### DIFF
--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -12,7 +12,7 @@ module Spree
       if new_locale.present? && supported_locale?(new_locale)
 
         if try_spree_current_user && try_spree_current_user.selected_locale != new_locale
-          try_spree_current_user.update(selected_locale: new_locale)
+          try_spree_current_user.update!(selected_locale: new_locale)
         end
 
         if should_build_new_url?

--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -11,8 +11,8 @@ module Spree
 
       if new_locale.present? && supported_locale?(new_locale)
 
-        if try_spree_current_user && try_spree_current_user.saved_locale != new_locale
-          try_spree_current_user.update(saved_locale: new_locale)
+        if try_spree_current_user && try_spree_current_user.selected_locale != new_locale
+          try_spree_current_user.update(selected_locale: new_locale)
         end
 
         if should_build_new_url?

--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -10,6 +10,11 @@ module Spree
       new_locale = (params[:switch_to_locale] || params[:locale]).to_s
 
       if new_locale.present? && supported_locale?(new_locale)
+
+        if try_spree_current_user && try_spree_current_user.saved_locale != new_locale
+          try_spree_current_user.update(saved_locale: new_locale)
+        end
+
         if should_build_new_url?
           redirect_to BuildLocalizedRedirectUrl.call(
             url: request.env['HTTP_REFERER'],


### PR DESCRIPTION
Now locale_controller changes saved_locale of user whenever the page's locale is changed and an user us logged in.

It's part of bigger set of changes meant to allow storing locale in user and retrieving it whenever user is revisiting a page/when we're meant to send them an email etc.
See also:
- https://github.com/spree/spree/pull/11814
- https://github.com/spree/spree_starter/pull/1039
- https://github.com/spree/spree_auth_devise/pull/574