### PR TITLE
change trying to access config directly to stubbing it

### DIFF
--- a/spec/controllers/controller_helpers_spec.rb
+++ b/spec/controllers/controller_helpers_spec.rb
@@ -10,9 +10,7 @@ describe Spree::ProductsController, type: :controller do
 
   before do
     I18n.enforce_available_locales = false
-    allow(Spree::Frontend::Config).to receive(:[]).with(:http_cache_enabled).and_call_original
-    allow(Spree::Frontend::Config).to receive(:[]).with(:products_filters).and_call_original
-    allow(Spree::Frontend::Config).to receive(:[]).with(:layout).and_call_original
+    allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
   end
 
   after do

--- a/spec/controllers/controller_helpers_spec.rb
+++ b/spec/controllers/controller_helpers_spec.rb
@@ -10,6 +10,9 @@ describe Spree::ProductsController, type: :controller do
 
   before do
     I18n.enforce_available_locales = false
+    allow(Spree::Frontend::Config).to receive(:[]).with(:http_cache_enabled).and_call_original
+    allow(Spree::Frontend::Config).to receive(:[]).with(:products_filters).and_call_original
+    allow(Spree::Frontend::Config).to receive(:[]).with(:layout).and_call_original
   end
 
   after do
@@ -27,7 +30,7 @@ describe Spree::ProductsController, type: :controller do
 
     context 'when Spree::Frontend::Config[:locale] not present' do
       before do
-        Spree::Frontend::Config[:locale] = nil
+        allow(Spree::Frontend::Config).to receive(:[]).with(:locale).and_return(nil)
       end
 
       context 'when rails application default locale not set' do
@@ -60,7 +63,7 @@ describe Spree::ProductsController, type: :controller do
     context 'when Spree::Frontend::Config[:locale] is present' do
       context 'and not in available_locales' do
         before do
-          Spree::Frontend::Config[:locale] = unavailable_locale
+          allow(Spree::Frontend::Config).to receive(:[]).with(:locale).and_return(unavailable_locale)
         end
 
         # FIXME: after adding supported_locales to Store this should be testable again
@@ -72,7 +75,7 @@ describe Spree::ProductsController, type: :controller do
 
       context 'and not in available_locales' do
         before do
-          Spree::Frontend::Config[:locale] = available_locale
+          allow(Spree::Frontend::Config).to receive(:[]).with(:locale).and_return(available_locale)
         end
 
         it 'sets the default locale based on Spree::Frontend::Config[:locale]' do

--- a/spec/controllers/controller_helpers_spec.rb
+++ b/spec/controllers/controller_helpers_spec.rb
@@ -14,7 +14,6 @@ describe Spree::ProductsController, type: :controller do
   end
 
   after do
-    Spree::Frontend::Config[:locale] = :en
     Rails.application.config.i18n.default_locale = :en
     I18n.locale = :en
     I18n.enforce_available_locales = true

--- a/spec/controllers/spree/home_controller_spec.rb
+++ b/spec/controllers/spree/home_controller_spec.rb
@@ -14,7 +14,10 @@ describe Spree::HomeController, type: :controller do
     end
 
     context 'different layout specified in config' do
-      before { Spree::Frontend::Config.layout = 'layouts/application' }
+      before do
+        allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+        allow(Spree::Frontend::Config).to receive(:[]).with(:layout).and_return('layouts/application')
+      end
 
       it 'renders specified layout' do
         get :index
@@ -23,7 +26,10 @@ describe Spree::HomeController, type: :controller do
     end
 
     context 'when http_cache_enabled is set to false' do
-      before { Spree::Frontend::Config[:http_cache_enabled] = false }
+      before do
+        allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+        allow(Spree::Frontend::Config).to receive(:[]).with(:http_cache_enabled).and_return(false)
+      end
 
       it 'does not call fresh_when method' do
         expect(subject).not_to receive(:fresh_when)

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -87,7 +87,10 @@ describe Spree::ProductsController, type: :controller do
     end
 
     context 'when http_cache_enabled is set to false' do
-      before { Spree::Frontend::Config[:http_cache_enabled] = false }
+      before do
+        allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+        allow(Spree::Frontend::Config).to receive(:[]).with(:http_cache_enabled).and_return(false)
+      end
 
       it 'does not call fresh_when method' do
         expect(subject).not_to receive(:fresh_when)

--- a/spec/controllers/spree/store_controller_spec.rb
+++ b/spec/controllers/spree/store_controller_spec.rb
@@ -25,7 +25,7 @@ describe Spree::StoreController, type: :controller do
     end
 
     context 'with signed in user' do
-      let(:user) { stub_model(Spree::LegacyUser)}
+      let(:user) { stub_model(Spree::LegacyUser) }
 
       before do
         allow(controller).to receive_messages try_spree_current_user: user

--- a/spec/controllers/spree/store_controller_spec.rb
+++ b/spec/controllers/spree/store_controller_spec.rb
@@ -25,7 +25,7 @@ describe Spree::StoreController, type: :controller do
     end
 
     context 'with signed in user' do
-      let(:user) { stub_model(Spree::LegacyUser) }
+      let(:user) { stub_model(Spree::LegacyUser)}
 
       before do
         allow(controller).to receive_messages try_spree_current_user: user
@@ -68,7 +68,7 @@ describe Spree::StoreController, type: :controller do
     end
     context 'when logged in' do
       before do
-        allow(controller).to receive_messages(try_spree_current_user: double('User', id: 1, last_incomplete_spree_order: nil))
+        allow(controller).to receive_messages(try_spree_current_user: double('User', id: 1, last_incomplete_spree_order: nil, selected_locale: nil))
       end
 
       it 'redirects forbidden path' do

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -132,7 +132,8 @@ describe 'homepage', type: :feature, js: true do
     let!(:hp_section_fr) { create(:cms_featured_article_section, cms_page: homepage_fr) }
 
     before do
-      Spree::Frontend::Config[:locale] = :fr
+      allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+      allow(Spree::Frontend::Config).to receive(:[]).with(:locale).and_return(:fr)
 
       hp_sec_de = Spree::CmsSection.find(hp_section_de.id)
 

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -91,13 +91,13 @@ describe 'setting locale', type: :feature, js: true do
   context 'without store locale set' do
     before do
       I18n.locale = locale
-      Spree::Frontend::Config[:locale] = locale
+      allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+      allow(Spree::Frontend::Config).to receive(:[]).with(:locale).and_return(locale)
       visit spree.cart_path
     end
 
     after do
       I18n.locale = 'en'
-      Spree::Frontend::Config[:locale] = 'en'
     end
 
     it_behaves_like 'translates cart page'

--- a/spec/features/main_nav_bar_spec.rb
+++ b/spec/features/main_nav_bar_spec.rb
@@ -12,7 +12,8 @@ describe 'Main navigation bar', type: :feature do
       let!(:stores) { create_list(:store, stores_number, default_country: create(:country)) }
 
       before do
-        Spree::Frontend::Config[:show_store_selector] = true
+        allow(Spree::Frontend::Config).to receive(:[]).with(anything).and_call_original
+        allow(Spree::Frontend::Config).to receive(:[]).with(:show_store_selector).and_return(true)
 
         visit spree.root_path
       end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -365,7 +365,10 @@ describe 'Visiting Products', type: :feature, inaccessible: true do
   end
 
   context 'pagination' do
-    before { Spree::Config.products_per_page = 3 }
+    before do
+      allow(Spree::Config).to receive(:[]).with(anything).and_call_original
+      allow(Spree::Config).to receive(:[]).with(:products_per_page).and_return(3)
+    end
 
     it 'is able to display products priced between 151 and 200 dollars across multiple pages' do
       find(:css, '#filtersPrice').click

--- a/spec/helpers/frontend_helper_spec.rb
+++ b/spec/helpers/frontend_helper_spec.rb
@@ -71,20 +71,24 @@ THIS IS THE BEST PRODUCT EVER!
           expect(description.strip).to eq(%Q{<p>\nTHIS IS THE BEST PRODUCT EVER!</p>"IT CHANGED MY LIFE" - Sue, MD})
         end
 
-        it 'renders a product description without any formatting based on configuration' do
-          initial_description = %Q{
-              <p>hello world</p>
+        context 'when configuration is set to not use formatting' do
 
-              <p>tihs is completely awesome and it works</p>
+          before { allow(Spree::Frontend::Config).to receive(:[]).with(:show_raw_product_description).and_return(true) }
 
-              <p>why so many spaces in the code. and why some more formatting afterwards?</p>
-          }
+          it 'renders a product description without any formatting' do
+            initial_description = %Q{
+                <p>hello world</p>
 
-          product.description = initial_description
+                <p>tihs is completely awesome and it works</p>
 
-          Spree::Frontend::Config[:show_raw_product_description] = true
-          description = product_description(product)
-          expect(description).to eq(initial_description)
+                <p>why so many spaces in the code. and why some more formatting afterwards?</p>
+            }
+
+            product.description = initial_description
+
+            description = product_description(product)
+            expect(description).to eq(initial_description)
+          end
         end
 
         context 'renders a product description default description incase description is blank' do

--- a/spec/helpers/store_helper_spec.rb
+++ b/spec/helpers/store_helper_spec.rb
@@ -47,9 +47,7 @@ module Spree
 
     describe '#should_render_store_chooser?' do
       context 'enabled' do
-        before { Spree::Frontend::Config.show_store_selector = true }
-
-        after { Spree::Frontend::Config.show_store_selector = false }
+        before { allow(Spree::Frontend::Config).to receive(:[]).with(:show_store_selector).and_return(true) }
 
         context 'with 1 store' do
           it { expect(should_render_store_chooser?).to be_falsey }
@@ -58,7 +56,9 @@ module Spree
         context 'with multiple stores' do
           before { create_list(:store, 2) }
 
-          it { expect(should_render_store_chooser?).to be_truthy }
+          it do
+            expect(should_render_store_chooser?).to be_truthy
+          end
         end
       end
 

--- a/spec/helpers/store_helper_spec.rb
+++ b/spec/helpers/store_helper_spec.rb
@@ -56,9 +56,7 @@ module Spree
         context 'with multiple stores' do
           before { create_list(:store, 2) }
 
-          it do
-            expect(should_render_store_chooser?).to be_truthy
-          end
+          it { expect(should_render_store_chooser?).to be_truthy }
         end
       end
 


### PR DESCRIPTION
A lot of tests try to change config directly, but since it is stored in the database the changes are not saved -> tests fail. I've changed it to simply mock config as only the behaviour of application based on config is tested here, no the config itself.